### PR TITLE
Compile fixes for CentOS 5-7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ LIBDIR        =  ../../cfitsio/lib
 
 # standard usage
 # recently added -std=c99 after a bug report
-COPTS = -funroll-loops -O3 -ansi -std=c99 -pedantic-errors -Wall -I$(CFITSIOINCDIR)
+COPTS = -funroll-loops -O3 -ansi -std=c99 -pedantic-errors -Wall -I$(CFITSIOINCDIR) -D_GNU_SOURCE
 LIBS  = -L$(LIBDIR) -lm -lcfitsio
 
 # compiler

--- a/extractkern.c
+++ b/extractkern.c
@@ -6,6 +6,8 @@
 #include<stdlib.h>
 #include<fitsio.h>
 
+#include "globals.h"
+
 #define max(x,y) x>y?x:y
 #define min(x,y) x<y?x:y
 


### PR DESCRIPTION
These two fixes allow me to compile on CentOS 5-7, both 32 and 64 bit versions.

To make sure not to confuse compilers which are not gcc, I decided to use
`-D_GNU_SOURCE` instead of `-std=gnu99` to fix the `gethostname()` error.
