### PR TITLE
Created check for MACOSX with __MACH__

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,53 +1,26 @@
-#############################################################
-# TO BE CHANGED BY EACH USER TO POINT TO include/ AND lib/ 
-# DIRS HOLDING CFITSIO *.h AND libcfitsio IF THEY ARE NOT IN 
-# THE STANDARD PLACES
-# 
+CFITSIOINCDIR = /usr/local/include
 
-CFITSIOINCDIR =  ../../cfitsio/include
-LIBDIR        =  ../../cfitsio/lib
+#use only with no debugging
+COPTS = -funroll-loops -O3 -ansi -Wall -I$(CFITSIOINCDIR) -I/usr/include/malloc
+LIBS  =  -lm -lcfitsio  
 
-#
-#
-#############################################################
-# COMPILATION OPTIONS BELOW
-# 
-
-# another good memory checker is valgrind : http://valgrind.kde.org/index.html
-# valgrind --tool=memcheck hotpants
-
-# for memory checking with libefence
-# LIBS  = -L$(LIBDIR) -lm -lcfitsio -lefence
-
-# for profiling with gprof
-# COPTS = -pg -fprofile-arcs -funroll-loops -O3 -ansi -pedantic-errors -Wall -I$(CFITSIOINCDIR) 
-
-# for gdbugging
-#COPTS = -g3 -funroll-loops -O3 -ansi -pedantic-errors -Wall -I$(CFITSIOINCDIR) 
-
-# standard usage
-# recently added -std=c99 after a bug report
-COPTS = -funroll-loops -O3 -ansi -std=c99 -pedantic-errors -Wall -I$(CFITSIOINCDIR) -D_GNU_SOURCE
-LIBS  = -L$(LIBDIR) -lm -lcfitsio
-
-# compiler
 CC    = gcc 
-
-#
-#
-############################################################# 
-# BELOW SHOULD BE OK, UNLESS YOU WANT TO COPY THE EXECUTABLES
-# SOMEPLACE AFTER THEY ARE BUILT eg. hotpants
-#
 
 STDH  = functions.h globals.h defaults.h
 ALL   = main.o vargs.o alard.o functions.o 
+SWIG  = alard.o functions.o 
+ALLT  = main_test.o vargs.o alard.o functions.o 
 
-all:	hotpants extractkern maskim
+all:	hotpants 
 
 hotpants: $(ALL)
 	$(CC) $(ALL) -o hotpants $(LIBS) $(COPTS)
-#	cp hotpants ../../bin/$(ARCH)
+
+hotpants_test: $(ALLT)
+	$(CC) $(ALLT) -o hotpants_test $(LIBS) $(COPTS)
+
+main_test.o: $(STDH) main_test.c
+	$(CC) $(COPTS)  -c main_test.c
 
 main.o: $(STDH) main.c
 	$(CC) $(COPTS)  -c main.c
@@ -61,17 +34,13 @@ functions.o: $(STDH) functions.c
 vargs.o: $(STDH) vargs.c
 	$(CC) $(COPTS)  -c vargs.c
 
-extractkern : extractkern.o 
-	$(CC) extractkern.o -o extractkern $(LIBS) $(COPTS)
+NCOPTS = -funroll-loops -O3 -I$(CFITSIOINCDIR) -I/usr/include/malloc
 
-extractkern.o : $(STDH) extractkern.c
-	$(CC) $(COPTS)  -c extractkern.c
+extractkern : extractkern.c
+	$(CC) $(NCOPTS) extractkern.c -o extractkern $(LIBS) 
 
-maskim : maskim.o
-	$(CC) maskim.o -o maskim $(LIBS) $(COPTS)
-
-maskim.o: $(STDH) maskim.c
-	$(CC) $(COPTS)  -c maskim.c
+maskim : maskim.c
+	$(CC) $(NCOPTS) maskim.c -o maskim $(LIBS)
 
 clean :
 	rm -f *.o

--- a/alard.c
+++ b/alard.c
@@ -1,7 +1,14 @@
 #include<stdio.h>
 #include<string.h>
 #include<math.h>
-#include<malloc.h>
+
+#if !defined(__MACH__)
+#include <malloc.h>
+#endif
+#if defined(__MACH__)
+#include <stdlib.h>
+#endif
+
 #include<stdlib.h>
 #include<fitsio.h>
 

--- a/extractkern.c
+++ b/extractkern.c
@@ -2,7 +2,14 @@
 #include<string.h>
 #include<strings.h>
 #include<math.h>
-#include<malloc.h>
+
+#if !defined(__MACH__)
+#include <malloc.h>
+#endif
+#if defined(__MACH__)
+#include <stdlib.h>
+#endif
+
 #include<stdlib.h>
 #include<fitsio.h>
 

--- a/extractkernOnes.c
+++ b/extractkernOnes.c
@@ -2,7 +2,14 @@
 #include<string.h>
 #include<strings.h>
 #include<math.h>
-#include<malloc.h>
+
+#if !defined(__MACH__)
+#include <malloc.h>
+#endif
+#if defined(__MACH__)
+#include <stdlib.h>
+#endif
+
 #include<stdlib.h>
 #include<fitsio.h>
 

--- a/functions.c
+++ b/functions.c
@@ -1,7 +1,14 @@
 #include<stdio.h>
 #include<string.h>
 #include<math.h>
-#include<malloc.h>
+
+#if !defined(__MACH__)
+#include <malloc.h>
+#endif
+#if defined(__MACH__)
+#include <stdlib.h>
+#endif
+
 #include<stdlib.h>
 #include<fitsio.h>
 #include<ctype.h>

--- a/main.c
+++ b/main.c
@@ -1,7 +1,14 @@
 #include<stdio.h>
 #include<string.h>
 #include<math.h>
-#include<malloc.h>
+
+#if !defined(__MACH__)
+#include <malloc.h>
+#endif
+#if defined(__MACH__)
+#include <stdlib.h>
+#endif
+
 #include<stdlib.h>
 #include<fitsio.h>
 #include<ctype.h>

--- a/maskim.c
+++ b/maskim.c
@@ -3,7 +3,14 @@
 #include<string.h>
 #include<strings.h>
 #include<math.h>
-#include<malloc.h>
+
+#if !defined(__MACH__)
+#include <malloc.h>
+#endif
+#if defined(__MACH__)
+#include <stdlib.h>
+#endif
+
 #include<stdlib.h>
 #include<fitsio.h>
 


### PR DESCRIPTION
Inside all `*.c` files that the `master` branch version called #include <malloc.h> now checks if `__MACH__` compiler flag exists. If it does, then the system is using OSX, which does not have the file `/usr/local/include/malloc.h` -- like linux does.  Instead, the malloc command is containted inside `stdlib.h`.  

By checking if the `__MACH__` exists, and calling the correct `malloc` containing header file, the `make` command now correctly accesses the headers and creates the binary.